### PR TITLE
Removed allRequirements on publishTrigger

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,15 @@
 target/
+project/project/
 
 # Metals / bloop
 .metals/
 .bloop/
+project/metals.sbt
+
 
 # Intellij
 .idea/
+
+#vscode
+.vscode/
 

--- a/README.md
+++ b/README.md
@@ -4,8 +4,6 @@ Gitlab dependency resolution and artifact publishing for sbt
 
 ```scala
 addSbtPlugin("com.gilcloud" % "sbt-gitlab" % "0.0.6") // in your project/plugins.sbt file
-
-enablePlugin(GitLabPlugin) // in your build.sbt file
 ```
 
 
@@ -15,7 +13,7 @@ This plugin requires sbt 1.0.0+
 
 ### Publishing to Gitlab via Gitlab CI/CD
 
-Utilizing the sbt publish command within GitLab CI/CD should require no additional configuration. This plugin Automaticall pulls the following GitLab environment variabls which should always be provided by default within GitLab Pipelines
+Utilizing the sbt publish command within GitLab CI/CD should require no additional configuration. This plugin automatically pulls the following GitLab environment variables which should always be provided by default within GitLab Pipelines
 
 ```shell
 $CI_JOB_TOKEN   # Access Token to authorize read/writes to the gitlab pakcage registry

--- a/README.md
+++ b/README.md
@@ -3,13 +3,53 @@
 Gitlab dependency resolution and artifact publishing for sbt
 
 ```scala
-addSbtPlugin("com.gilcloud" % "sbt-gitlab" % "0.0.4")
+addSbtPlugin("com.gilcloud" % "sbt-gitlab" % "0.0.6") // in your project/plugins.sbt file
+
+enablePlugin(GitLabPlugin) // in your build.sbt file
 ```
+
 
 ## Usage
 
 This plugin requires sbt 1.0.0+
 
+### Publishing to Gitlab via Gitlab CI/CD
+
+Utilizing the sbt publish command within GitLab CI/CD should require no additional configuration. This plugin Automaticall pulls the following GitLab environment variabls which should always be provided by default within GitLab Pipelines
+
+```shell
+$CI_JOB_TOKEN   # Access Token to authorize read/writes to the gitlab pakcage registry
+$CI_PROJECT_ID  # Project ID for active project pipeline. Used so Gitlab knows what project to publish the artifact under
+$CI_GROUP_ID    # Gitlab Groupt ID. Used for fetching Artifacts published under the specified Group. 
+                # In a pipeline this would be set to the id of the group the project is under (when applicable)
+$CI_SERVER_HOST # The host name for gitlab defaults to gitlab.com
+```
+
+Any of these 'defaults' can be overwritten in your build.sbt file
+
+```scala
+import com.gilcloud.sbt.gitlab.{GitlabCredentials,GitlabPlugin}
+
+GitlabPlugin.autoImport.gitlabGroupId     :=  Some(12345)
+GitlabPlugin.autoImport.gitlabProjectId   :=  Some(12345)
+GitlabPlugin.autoImport.gitlabDomain      :=  "my-gitlab-host.com"
+GitlabPlugin.autoImport.GitlabCredentials :=  Some(GitlabCredentials("Private-Token","<API-KEY>"))
+
+// Alternatively for credential managment 
+// ideal for pulling artifacts locally and keeping tokens out of your source control
+// see below for sample .credentials file
+credentials += Credentials(Path.userHome / ".sbt" / ".credentials.gitlab"),
+
+```
+> ~/.sbt/.credentials.gitlab
+```.credentials
+realm=gitlab
+host=my-git-lab-host
+user=Private-Token
+password=<API-KEY>
+```
+
+In order to publish to 
 ### Testing
 
 Run `test` for regular unit tests.

--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 name := "sbt-gitlab"
 organization := "com.gilcloud"
-version := "0.0.5"
+version := "0.0.6"
 description := "publishing and dependency resolution for gitlab both private and hosted using header auth"
 sbtPlugin := true
 

--- a/src/main/scala/com/gilcloud/sbt/gitlab/GitlabPlugin.scala
+++ b/src/main/scala/com/gilcloud/sbt/gitlab/GitlabPlugin.scala
@@ -32,8 +32,6 @@ object GitlabPlugin extends AutoPlugin {
   }
   import autoImport._
 
-  override def trigger: PluginTrigger = allRequirements
-
   override def globalSettings =
     Seq(
       gitlabDomain := "gitlab.com"

--- a/src/main/scala/com/gilcloud/sbt/gitlab/GitlabPlugin.scala
+++ b/src/main/scala/com/gilcloud/sbt/gitlab/GitlabPlugin.scala
@@ -17,7 +17,7 @@ object GitlabPlugin extends AutoPlugin {
   
   lazy val headerAuthHandler =
     taskKey[Unit]("perform auth using header credentials")
-    
+
   // This plugin will load automatically
   override def trigger: PluginTrigger = allRequirements
 
@@ -61,9 +61,12 @@ object GitlabPlugin extends AutoPlugin {
           downloader: URLHandler
       ): Unit = {}
     }
-
+  
   override def projectSettings: Seq[Def.Setting[_]] =
-    inScope(publish.scopedKey.scope)(Seq(
+    inScope(publish.scopedKey.scope)(gitLabProjectSettings)
+
+  val gitLabProjectSettings : Seq[Def.Setting[_]] = 
+    Seq(
       publishMavenStyle := true,
       gitlabDomain := sys.env.getOrElse("CI_SERVER_HOST", "gitlab.com"),
       gitlabProjectId := sys.env
@@ -107,5 +110,5 @@ object GitlabPlugin extends AutoPlugin {
         gitlabProjectId.value.map(p => "gitlab-maven" at s"https://${gitlabDomain.value}/api/v4/projects/$p/packages/maven") orElse
         gitlabGroupId.value.map(g => "gitlab-maven" at s"https://${gitlabDomain.value}/api/v4/groups/$g/-/packages/maven")
       }
-    ))
+    )
 }

--- a/src/main/scala/com/gilcloud/sbt/gitlab/GitlabPlugin.scala
+++ b/src/main/scala/com/gilcloud/sbt/gitlab/GitlabPlugin.scala
@@ -32,11 +32,6 @@ object GitlabPlugin extends AutoPlugin {
   }
   import autoImport._
 
-  override def globalSettings =
-    Seq(
-      gitlabDomain := "gitlab.com"
-    )
-
   def headerEnrichingClientBuilder(
       existingBuilder: OkHttpClient.Builder,
       domain: String,
@@ -67,6 +62,7 @@ object GitlabPlugin extends AutoPlugin {
   override def projectSettings: Seq[Def.Setting[_]] =
     Seq(
       publishMavenStyle := true,
+      gitlabDomain := sys.env.getOrElse("CI_SERVER_HOST", "gitlab.com"),
       gitlabProjectId := sys.env
         .get("CI_PROJECT_ID")
         .flatMap(str => Try(str.toInt).toOption),

--- a/src/main/scala/com/gilcloud/sbt/gitlab/GitlabPlugin.scala
+++ b/src/main/scala/com/gilcloud/sbt/gitlab/GitlabPlugin.scala
@@ -9,14 +9,17 @@ import org.apache.ivy.util.url.{
 import sbt.Keys._
 import sbt.internal.CustomHttp
 import sbt.internal.librarymanagement.ivyint.GigahorseUrlHandler
-import sbt.{Credentials, Def, _}
+import sbt._
 
 import scala.util.Try
 object GitlabPlugin extends AutoPlugin {
 
+  
   lazy val headerAuthHandler =
     taskKey[Unit]("perform auth using header credentials")
+    
   // This plugin will load automatically
+  override def trigger: PluginTrigger = allRequirements
 
   object autoImport {
 
@@ -60,7 +63,7 @@ object GitlabPlugin extends AutoPlugin {
     }
 
   override def projectSettings: Seq[Def.Setting[_]] =
-    Seq(
+    inScope(publish.scopedKey.scope)(Seq(
       publishMavenStyle := true,
       gitlabDomain := sys.env.getOrElse("CI_SERVER_HOST", "gitlab.com"),
       gitlabProjectId := sys.env
@@ -104,5 +107,5 @@ object GitlabPlugin extends AutoPlugin {
         gitlabProjectId.value.map(p => "gitlab-maven" at s"https://${gitlabDomain.value}/api/v4/projects/$p/packages/maven") orElse
         gitlabGroupId.value.map(g => "gitlab-maven" at s"https://${gitlabDomain.value}/api/v4/groups/$g/-/packages/maven")
       }
-    )
+    ))
 }


### PR DESCRIPTION
the `trigger` override appears to be the root cause for #7 

If I'm being perfectly honest I do not fully understand the implications or reasons behind this change but some local testing appeared to have the desired behavior once this line was removed. 

From the documentation I gather that all this setting should do is allow the plugin to be enabled automatically without needing an explicit `enablePlugin(GitLabPlugin)` But with it set it appears to be causing something weird with the scoping of this plugin. Perhaps some stricter scoping requirements are needed, which could be another solution. But this is where my lack of sbt knowledge is hindering me. 

If I find some time maybe I'll poke at it a bit more to see if there is a way to retain this setting with some more explicit scoping / requirement rules in place.
