### PR TITLE
fix None.get

### DIFF
--- a/src/main/scala/com/gilcloud/sbt/gitlab/GitlabPlugin.scala
+++ b/src/main/scala/com/gilcloud/sbt/gitlab/GitlabPlugin.scala
@@ -79,8 +79,11 @@ object GitlabPlugin extends AutoPlugin {
         .value,
       publish := publish.dependsOn(headerAuthHandler).value,
       publishTo := (ThisProject / publishTo).value.orElse {
-        gitlabProjectId.value.map(p => "gilcloud-sbt-gitlab-maven" at s"https://${gitlabDomain.value}/api/v4/projects/$p/packages/maven") orElse
-        gitlabGroupId.value.map(g => "gilcloud-sbt-gitlab-maven" at s"https://${gitlabDomain.value}/api/v4/groups/$g/-/packages/maven")
+        gitlabProjectId.value.flatMap { p =>
+          Some( "gilcloud-sbt-gitlab-maven" at s"https://${gitlabDomain.value}/api/v4/projects/$p/packages/maven")
+        } orElse gitlabGroupId.value.flatMap { g =>
+          Some( "gilcloud-sbt-gitlab-maven" at s"https://${gitlabDomain.value}/api/v4/groups/$g/-/packages/maven")
+        }
       }
     )
 }


### PR DESCRIPTION
Refactor `publishTo` to add conditional logic for Gitlab project and group IDs. If `gitlabProjectId` is present, `publishTo` will be set to the project Maven repository URL. If not, but `gitlabGroupId` is present, `publishTo` will be set to the group Maven repository URL.